### PR TITLE
Add aeson instances behind a cabal flag

### DIFF
--- a/src/Data/ULID/Aeson.hs
+++ b/src/Data/ULID/Aeson.hs
@@ -1,0 +1,24 @@
+module Data.ULID.Aeson () where
+
+import Data.ULID
+import Data.ULID.Random
+import Data.Aeson
+import Data.Aeson.Encoding (string)
+import Data.String (IsString(fromString))
+import Data.Aeson.Types (Parser)
+
+instance FromJSON ULID where
+    parseJSON value =
+         read <$> parseJSON value
+
+instance ToJSON ULID where
+    toJSON = fromString . show
+    toEncoding = string . show
+
+instance FromJSON ULIDRandom where
+    parseJSON value =
+         read <$> parseJSON value
+
+instance ToJSON ULIDRandom where
+    toJSON = fromString . show
+    toEncoding = string . show

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,5 @@
 resolver: lts-18.24
 packages: ['.']
+flags:
+  ulid:
+    aeson: true

--- a/test/Data/ULID/AesonSpec.hs
+++ b/test/Data/ULID/AesonSpec.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE TypeApplications #-}
+module Data.ULID.AesonSpec where
+
+import Data.ULID
+import Data.ULID.Random
+import Data.ByteString.Lazy
+import qualified Data.Aeson as Aeson
+import Data.Text.Lazy.Encoding
+import Data.Text.Lazy as T
+import Data.ULID.Aeson ()
+
+import Test.Hspec
+import Data.String (IsString(fromString))
+
+
+spec :: Spec
+spec = do
+  describe "ULID fromJson/toJson" $ do
+    it "Same after encode -> decode" $ do
+        ulid <- getULID
+        Aeson.eitherDecode (Aeson.encode ulid) `shouldBe` Right ulid
+        read (show ulid) `shouldBe` ulid
+
+    it "decodes similar to read" $ do
+        ulid_str <- show <$> getULID
+        let
+            ulid_bs :: ByteString
+            ulid_bs = encodeUtf8 $ T.pack ("\"" <> ulid_str <> "\"")
+        Aeson.eitherDecode ulid_bs `shouldBe` Right (read @ULID ulid_str)
+
+  describe "ULIDRandom fromJson/toJson" $ do
+    it "Same after encode -> decode" $ do
+        ulid <- getULIDRandom
+        Aeson.eitherDecode (Aeson.encode ulid) `shouldBe` Right ulid
+        read (show ulid) `shouldBe` ulid
+
+    it "decodes similar to read" $ do
+        ulid_str <- show <$> getULIDRandom
+        let
+            ulid_bs :: ByteString
+            ulid_bs = encodeUtf8 $ T.pack ("\"" <> ulid_str <> "\"")
+        Aeson.eitherDecode ulid_bs `shouldBe` Right (read @ULIDRandom ulid_str)

--- a/ulid.cabal
+++ b/ulid.cabal
@@ -19,6 +19,10 @@ build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
 
+flag aeson
+  description: build json de-/encoding via aeson
+  default: False
+
 
 library
   hs-source-dirs:      src
@@ -39,6 +43,9 @@ library
                     ,  time
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings
+  if flag(aeson)
+    build-depends: aeson
+    exposed-modules: Data.ULID.Aeson
 
 
 executable ulid-exe
@@ -55,7 +62,8 @@ test-suite ulid-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
-  other-modules:       Data.ULID.Base32Spec
+  other-modules:       Data.ULID.AesonSpec
+                     , Data.ULID.Base32Spec
                      , Data.ULID.RandomSpec
                      , Data.ULID.TimeStampSpec
                      , Data.ULIDSpec
@@ -66,6 +74,8 @@ test-suite ulid-test
                      , binary
                      , random
                      , hashable
+                     , aeson
+                     , text
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings


### PR DESCRIPTION
I'm not a very experienced haskell contributor, so let me know what you think.

I wasn't sure if making `From/ToJSON` depend on `Read/Show` is a good idea, but I think it makes sense for ULIDs