### PR TITLE
Fix lexicographic ordering when timestamps are the same

### DIFF
--- a/src/Data/ULID.hs
+++ b/src/Data/ULID.hs
@@ -62,10 +62,7 @@ data ULID = ULID
   { timeStamp :: !ULIDTimeStamp
   , random    :: !ULIDRandom
   }
-  deriving (Eq, Typeable, Data, Generic)
-
-instance Ord ULID where
-    compare (ULID ts1 _) (ULID ts2 _) = compare ts1 ts2
+  deriving (Eq, Ord, Typeable, Data, Generic)
 
 instance Show ULID where
     show (ULID ts bytes) = show ts ++ show bytes

--- a/src/Data/ULID/Random.hs
+++ b/src/Data/ULID/Random.hs
@@ -29,7 +29,7 @@ import qualified Data.ULID.Base32 as B32
 
 -- | Newtype wrapping a `ByteString`
 newtype ULIDRandom = ULIDRandom BS.ByteString
-    deriving (Eq, Typeable, Data, Generic)
+    deriving (Eq, Ord, Typeable, Data, Generic)
 
 instance Show ULIDRandom where
     show (ULIDRandom r) = T.unpack $ B32.encode 16 . roll . BS.unpack $ r

--- a/test/Data/ULIDSpec.hs
+++ b/test/Data/ULIDSpec.hs
@@ -6,12 +6,14 @@ import           Data.Binary
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Char
 import           Data.Hashable
-import           Data.List            (nub, sort)
+import           Data.List            (nub, sort, sortOn)
 import qualified System.Random        as R
 
 import           Data.ULID
 
 import           Test.Hspec
+import Data.ULID.TimeStamp (getULIDTimeStamp)
+import Data.ULID.Random (getULIDRandom)
 
 
 spec :: Spec
@@ -33,6 +35,20 @@ spec = do
         let l = [show u3, show u2, show u4, show u1]
         let l' = sort l
         l' `shouldBe` [show u1, show u2, show u3, show u4]
+
+        -- it should be lexicographically sortable even if the timestamps are the same
+        ts <- getULIDTimeStamp
+        ur1 <- getULIDRandom
+        ur2 <- getULIDRandom
+        ur3 <- getULIDRandom
+        ur4 <- getULIDRandom
+
+        let u5 = ULID ts ur1
+        let u6 = ULID ts ur2
+        let u7 = ULID ts ur3
+        let u8 = ULID ts ur4
+
+        sort [u5, u6, u7, u8] `shouldBe` sortOn show [u5, u6, u7, u8]
 
         -- make sure it works in internal representation too :)
         let ul = [u3, u2, u4, u1]


### PR DESCRIPTION
`ULID`s are currently not lexicographically sortable unless they have the same timestamp.

This is also has alarming consequences where members `Set`s of `ULID` will be treated as equal if the timestamps are the same but have different random components.

This change ensures that they will be sorted correctly even if the timestamps are identical.

See also: https://github.com/haskell-github-trust/ulid/issues/15



