### PR TITLE
Fix show compile error

### DIFF
--- a/src/Data/ULID.hs
+++ b/src/Data/ULID.hs
@@ -42,7 +42,8 @@ import qualified Data.ByteString.Lazy  as LBS
 import           Data.Data
 import           Data.Hashable
 import           Data.Monoid           ((<>))
-import           Data.Text as T
+import           Data.Text             (Text)
+import qualified Data.Text             as T
 import           Data.Time.Clock.POSIX
 import           GHC.Generics
 import           System.IO.Unsafe


### PR DESCRIPTION
Fixes the following compile error:

```
src/Data/ULID.hs:71:28: error:
    Ambiguous occurrence ‘show’
    It could refer to
       either ‘Prelude.show’,
              imported from ‘Prelude’ at src/Data/ULID.hs:31:8-16
              (and originally defined in ‘GHC.Show’)
           or ‘T.show’,
              imported from ‘Data.Text’ at src/Data/ULID.hs:45:1-31
   |
71 |     show (ULID ts bytes) = show ts ++ show bytes
   |                            ^^^^

src/Data/ULID.hs:71:39: error:
    Ambiguous occurrence ‘show’
    It could refer to
       either ‘Prelude.show’,
              imported from ‘Prelude’ at src/Data/ULID.hs:31:8-16
              (and originally defined in ‘GHC.Show’)
           or ‘T.show’,
              imported from ‘Data.Text’ at src/Data/ULID.hs:45:1-31
   |
71 |     show (ULID ts bytes) = show ts ++ show bytes
   |                                       ^^^^
```